### PR TITLE
Eliminate dead LogicalOperators

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,27 @@ export default function () {
       }
     },
 
+    LogicalExpression: {
+      exit(path) {
+        const { node } = path;
+        var operator = path.get("operator").node;
+        var leftOfOperatorTest = path.get("left").evaluateTruthy();
+        if (operator === "&&") {
+          if (leftOfOperatorTest === true) {
+            path.replaceWith(node.right);
+          } else if (leftOfOperatorTest === false) {
+            path.replaceWith(node.left);
+          }
+        } else if (operator === "||") {
+          if (leftOfOperatorTest === true) {
+            path.replaceWith(node.left);
+          } else if (leftOfOperatorTest === false) {
+            path.replaceWith(node.right);
+          }
+        }
+      }
+    },
+
     BlockStatement(path) {
       var paths = path.get("body");
 

--- a/test/fixtures/logical-expression/actual.js
+++ b/test/fixtures/logical-expression/actual.js
@@ -1,0 +1,10 @@
+true && foo();
+1 && foo();
+false && foo();
+0 && foo();
+bar() && foo();
+false || foo();
+0 || foo();
+true || foo();
+1 || foo();
+bar() || foo();

--- a/test/fixtures/logical-expression/expected.js
+++ b/test/fixtures/logical-expression/expected.js
@@ -1,0 +1,10 @@
+foo();
+foo();
+false;
+0;
+bar() && foo();
+foo();
+foo();
+true;
+1;
+bar() || foo();


### PR DESCRIPTION
Hi! I hope you'll accept this feature-request-as-pull-request which simplifies `&&` and `||` operators.