### PR TITLE
Ensure unreachable code and if-statement simplification work together

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -123,21 +123,23 @@ export default function () {
       }
     },
 
-    BlockStatement(path) {
-      var paths = path.get("body");
+    BlockStatement: {
+      exit(path) {
+        var paths = path.get("body");
 
-      var purge = false;
+        var purge = false;
 
-      for (var i = 0; i < paths.length; i++) {
-        let path = paths[i];
+        for (var i = 0; i < paths.length; i++) {
+          let path = paths[i];
 
-        if (!purge && t.isCompletionStatement(path)) {
-          purge = true;
-          continue;
-        }
+          if (!purge && t.isCompletionStatement(path)) {
+            purge = true;
+            continue;
+          }
 
-        if (purge && !t.isFunctionDeclaration(path)) {
-          path.remove();
+          if (purge && !t.isFunctionDeclaration(path)) {
+            path.remove();
+          }
         }
       }
     },

--- a/test/fixtures/if-statement-and-unreachable/actual.js
+++ b/test/fixtures/if-statement-and-unreachable/actual.js
@@ -1,0 +1,6 @@
+(function (x) {
+	if (true) {
+		return x;
+	}
+	throw new Error('untrue');
+})();

--- a/test/fixtures/if-statement-and-unreachable/expected.js
+++ b/test/fixtures/if-statement-and-unreachable/expected.js
@@ -1,0 +1,3 @@
+(function (x) {
+	return x;
+})();


### PR DESCRIPTION
Previously the following:

```js
if (true) return;
throw new Error();
```
would become
```js
return;
throw new Error();
```
But obviously it should be:
```js
return;
```
